### PR TITLE
Changed subprocess run user from current to k2hdkc

### DIFF
--- a/src/override.conf
+++ b/src/override.conf
@@ -29,7 +29,9 @@
 
 /etc/antpickax/k2hr3-get-resource-helper.conf:OUTPUT_FILE      = k2hdkc.ini
 /etc/antpickax/chmpx-service-helper.conf:CHMPX_INI_CONF_FILE   = k2hdkc.ini
+/etc/antpickax/chmpx-service-helper.conf:SUBPROCESS_USER       = k2hdkc
 /etc/antpickax/k2hdkc-service-helper.conf:K2HDKC_INI_CONF_FILE = k2hdkc.ini
+/etc/antpickax/k2hdkc-service-helper.conf:SUBPROCESS_USER      = k2hdkc
 
 #
 # Local variables:


### PR DESCRIPTION
## Relevant Issue (if applicable)
n/a

## Details
The execution user of CHMPX / K2HDKC has been changed from the default (systemd execution user: root) to the k2hdkc user.

