### PR TITLE
Added post install process for process execution user

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,7 @@ RELEASE_VERSION
 *.trs
 buildutils/control
 buildutils/copyright
+buildutils/*.postinst
 rpmbuild
 rpmbuild/*
 debian

--- a/buildutils/debian_build.sh
+++ b/buildutils/debian_build.sh
@@ -292,6 +292,14 @@ if [ ! -f ${EXPANDDIR}/debian/compat ]; then
 	echo "9" > ${EXPANDDIR}/debian/compat
 fi
 
+#
+# preinst/postinst/prerm/postrm
+#
+if [ -f ${MYSCRIPTDIR}/${PACKAGE_NAME}.postinst ]; then
+	cp -p ${MYSCRIPTDIR}/${PACKAGE_NAME}.postinst ${EXPANDDIR}/debian/${PACKAGE_NAME}.postinst || exit 1
+	chmod +x ${EXPANDDIR}/debian/${PACKAGE_NAME}.postinst || exit 1
+fi
+
 echo "===== prepare working directory: end ==============="
 
 #

--- a/buildutils/k2hdkc-dbaas-override-conf.postinst.in
+++ b/buildutils/k2hdkc-dbaas-override-conf.postinst.in
@@ -1,3 +1,4 @@
+#!/bin/sh
 #
 # K2HDKC DBaaS Utilities - Override configuration for K2HDKC DBaaS
 #
@@ -14,16 +15,13 @@
 # the license file that was distributed with this source code.
 #
 # AUTHOR:   Takeshi Nakatani
-# CREATE:   Fri Jan 22 2021
+# CREATE:   Fri May 12 2021
 # REVISION:
 #
 
-EXTRA_DIST =make_variables.sh \
-			make_release_version_file.sh \
-			make_rpm_changelog.sh \
-			make_postinst_script.sh \
-			debian_build.sh \
-			rpm_build.sh
+@POSTINST_SCRIPT_DEB@
+
+exit 0
 
 #
 # Local variables:

--- a/buildutils/k2hdkc-dbaas-override-conf.spec.in
+++ b/buildutils/k2hdkc-dbaas-override-conf.spec.in
@@ -76,6 +76,9 @@ foundation for K2HDKC DBaaS.
 %make_install
 install -D -m 644 src/override.conf %{buildroot}/etc/antpickax/override.conf
 
+%post
+@POSTINST_SCRIPT_RPM@
+
 %if %{make_check}
 %check
 %{__make} check

--- a/buildutils/make_postinst_script.sh
+++ b/buildutils/make_postinst_script.sh
@@ -1,0 +1,135 @@
+#!/bin/sh
+#
+# K2HDKC DBaaS Utilities - Override configuration for K2HDKC DBaaS
+#
+# Copyright 2021 Yahoo! Japan Corporation.
+#
+# K2HDKC DBaaS is a DataBase as a Service provided by Yahoo! JAPAN
+# which is built K2HR3 as a backend and provides services in
+# cooperation with OpenStack.
+# The Override configuration for K2HDKC DBaaS serves to connect the
+# components that make up the K2HDKC DBaaS. K2HDKC, K2HR3, CHMPX,
+# and K2HASH are components provided as AntPickax.
+#
+# For the full copyright and license information, please view
+# the license file that was distributed with this source code.
+#
+# AUTHOR:   Takeshi Nakatani
+# CREATE:   Fri May 12 2021
+# REVISION:
+#
+
+#
+# Return post install script common body data
+#
+func_usage()
+{
+	echo ""
+	echo "Usage:  $1 [rpm|deb] [--help(-h)]"
+	echo "	[rpm|deb]    for rpm package or debian package"
+	echo "	--help(-h)   print help."
+	echo ""
+}
+
+#
+# Common variables
+#
+PRGNAME=$(basename "$0")
+MYSCRIPTDIR=$(dirname "$0")
+SRCTOP=$(cd "${MYSCRIPTDIR}/.."; pwd)
+
+#
+# Check options
+#
+TARGET_TYPE=""
+while [ $# -ne 0 ]; do
+	if [ "X$1" = "X" ]; then
+		break;
+
+	elif [ "X$1" = "X-h" -o "X$1" = "X-H" -o "X$1" = "X--help" -o "X$1" = "X--HELP" ]; then
+		func_usage "${PRGNAME}"
+		exit 0
+
+	elif [ "X$1" = "Xdeb" -o "X$1" = "XDEB" -o "X$1" = "Xdebian" -o "X$1" = "XDEBIAN" ]; then
+		if [ "X${TARGET_TYPE}" != "X" ]; then
+			echo "[ERROR] rpm or deb option is already specified."
+		fi
+		TARGET_TYPE="deb"
+
+	elif [ "X$1" = "Xrpm" -o "X$1" = "XRPM" ]; then
+		if [ "X${TARGET_TYPE}" != "X" ]; then
+			echo "[ERROR] rpm or deb option is already specified."
+		fi
+		TARGET_TYPE="rpm"
+
+	else
+		echo "[ERROR] Unknown option($1) is specified."
+	fi
+	shift
+done
+if [ "X${TARGET_TYPE}" = "X" ]; then
+	echo "[ERROR] rpm or deb option must be specified."
+	exit 1
+fi
+
+#
+# Script body
+#
+_SCRIPT_BODY=$(cat<<EOS
+if [ -d /etc/antpickax -a -f /etc/antpickax/k2hr3-api-uri -a -f /etc/antpickax/k2hr3-role-name -a -f /etc/antpickax/k2hr3-role-name -a -f /etc/antpickax/k2hr3-cuk-param ]; then
+	K2HR3_URI=\$(cat /etc/antpickax/k2hr3-api-uri)
+	K2HR3_ROLE=\$(cat /etc/antpickax/k2hr3-role-name)
+	K2HR3_RESOURCE=\$(cat /etc/antpickax/k2hr3-role-name | sed 's/:role:/:resource:/g')
+	K2HR3_CUK=\$(cat /etc/antpickax/k2hr3-cuk-param)
+	K2HDKC_PROC_USER="k2hdkc"
+	K2HR3_RESULT=\$(curl -s -X GET -H 'Content-Type: application/json' "\${K2HR3_URI}"/v1/resource/"\${K2HR3_RESOURCE}"?"\${K2HR3_CUK}"\&role="\${K2HR3_ROLE}"\&type=keys\&keyname=k2hdkc-dbaas-proc-user)
+	echo "\${K2HR3_RESULT}" | grep -q '"result":true'
+	if [ \$? -eq 0 ]; then
+		K2HDKC_PROC_USER=\$(echo "\${K2HR3_RESULT}" | sed 's/^.*\"resource\":\"\([^\"]*\)*\".*\$/\1/g' | grep -v "[^a-zA-Z0-9_]")
+		if [ "X\${K2HDKC_PROC_USER}" != "X" ]; then
+			sed -i -e "s/chmpx-service-helper.conf:SUBPROCESS_USER[[:space:]]*=.*\$/chmpx-service-helper.conf:SUBPROCESS_USER\t\t= \${K2HDKC_PROC_USER}/g" -e "s/k2hdkc-service-helper.conf:SUBPROCESS_USER[[:space:]]*=.*\$/k2hdkc-service-helper.conf:SUBPROCESS_USER\t\t= \${K2HDKC_PROC_USER}/g" /etc/antpickax/override.conf
+		else
+			K2HDKC_PROC_USER="k2hdkc"
+		fi
+	fi
+	K2HR3_RESULT=\$(curl -s -X GET -H 'Content-Type: application/json' "\${K2HR3_URI}"/v1/resource/"\${K2HR3_RESOURCE}"?"\${K2HR3_CUK}"\&role="\${K2HR3_ROLE}"\&type=keys\&keyname=k2hdkc-dbaas-add-user)
+	echo "\${K2HR3_RESULT}" | grep -q '"result":true'
+	if [ \$? -eq 0 ]; then
+		K2HDKC_ADD_USER=\$(echo "\${K2HR3_RESULT}" | sed 's/^.*\"resource\":\(.*\)}.*\$/\1/g')
+		if [ "X\${K2HDKC_ADD_USER}" = "X1" ]; then
+			id -u "\${K2HDKC_PROC_USER}" >/dev/null 2>&1
+			if [ \$? -ne 0 ]; then
+				grep -q "^\${K2HDKC_PROC_USER}:" /etc/group
+				if [ \$? -ne 0 ]; then
+					useradd -s /bin/sh -d /home/"\${K2HDKC_PROC_USER}" -m "\${K2HDKC_PROC_USER}"
+				else
+					useradd -s /bin/sh -d /home/"\${K2HDKC_PROC_USER}" -m "\${K2HDKC_PROC_USER}" -g "\${K2HDKC_PROC_USER}"
+				fi
+			fi
+		fi
+	fi
+fi
+EOS
+)
+
+#
+# Main
+#
+if [ "X${TARGET_TYPE}" = "Xdeb" ]; then
+	/bin/echo "${_SCRIPT_BODY}"
+else
+	/bin/echo "if [ \"\$1\" -eq 1 ]; then"
+	/bin/echo "${_SCRIPT_BODY}" | sed -e 's/^/\t/g' -e 's/\t/    /g'
+	/bin/echo "fi"
+fi
+
+exit 0
+
+#
+# Local variables:
+# tab-width: 4
+# c-basic-offset: 4
+# End:
+# vim600: noexpandtab sw=4 ts=4 fdm=marker
+# vim<600: noexpandtab sw=4 ts=4
+#

--- a/configure.ac
+++ b/configure.ac
@@ -49,6 +49,8 @@ AC_SUBST([PKGLICENSE], "`grep License COPYING | sed 's/ License//g'`")
 AC_SUBST([DEBCOPYING], "`tail -n +5 COPYING | sed 's/^$/./g' | sed 's/^/ /g'`")
 AC_SUBST([DEBHELPER_DEP], "`$(pwd)/buildutils/make_variables.sh -debhelper_dep`")
 AC_SUBST([RPMPKG_GROUP], ["`$(pwd)/buildutils/make_variables.sh -rpmpkg_group | sed 's#NEEDRPMGROUP#Group: Applications/Other#g'`"])
+AC_SUBST([POSTINST_SCRIPT_RPM], ["`$(pwd)/buildutils/make_postinst_script.sh rpm`"])
+AC_SUBST([POSTINST_SCRIPT_DEB], ["`$(pwd)/buildutils/make_postinst_script.sh deb`"])
 AC_SUBST([CONFIGUREWITHOPT], "")
 AM_SUBST_NOTMAKE([CURRENTREV])
 AM_SUBST_NOTMAKE([RPMCHANGELOG])
@@ -56,6 +58,8 @@ AM_SUBST_NOTMAKE([SHORTDESC])
 AM_SUBST_NOTMAKE([DEBCOPYING])
 AM_SUBST_NOTMAKE([DEBHELPER_DEP])
 AM_SUBST_NOTMAKE([RPMPKG_GROUP])
+AM_SUBST_NOTMAKE([POSTINST_SCRIPT_RPM])
+AM_SUBST_NOTMAKE([POSTINST_SCRIPT_DEB])
 AM_SUBST_NOTMAKE([CONFIGUREWITHOPT])
 
 #
@@ -72,7 +76,8 @@ AC_CONFIG_FILES([Makefile
 				buildutils/Makefile
 				buildutils/control
 				buildutils/copyright
-				buildutils/k2hdkc-dbaas-override-conf.spec])
+				buildutils/k2hdkc-dbaas-override-conf.spec
+				buildutils/k2hdkc-dbaas-override-conf.postinst])
 
 AC_OUTPUT
 


### PR DESCRIPTION
## Relevant Issue (if applicable)
n/a

## Details
The purpose of the packages provided by this repository is to distribute the `/etc/antpickax/override.conf` file.
And distribute for K2HDKC DBaaS system.
This PR is that the execution user of the `chmpx` and `k2hdkc` processes running on the host where this package is installed can be controlled from K2HR3 system.
It can be controlled by setting the following values in the `keys` of the `RESOURCE` corresponding to the `ROLE` of the K2HR3 system in which the host is registered.
If each key is set, override.conf will be set appropriately during the `post` phase of package installation.
And it can also create users.

- k2hdkc-dbaas-proc-user  
Set the execution user of each process. If not set, it will continue to run as the `k2hdkc` user by default.
- k2hdkc-dbaas-add-user  
If this value is set to 1, the execution user for each process (including the default `k2hdkc` user) does not exist on the system, it is created during installation.


